### PR TITLE
Add missing Test::MockModule dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,7 @@ my %WriteMakefileArgs = (
     "IO::Handle" => 0,
     "IPC::Open3" => 0,
     "Test::CheckDeps" => "0.010",
+    "Test::MockModule" => 0,
     "Test::More" => "0.98"
   },
   "VERSION" => "0.001",

--- a/cpanfile
+++ b/cpanfile
@@ -16,6 +16,7 @@ requires 'IO::Async::Timer::Periodic', '>= 0.72';
 
 on test => sub {
     requires 'Test::More', '>= 0.98';
+    requires 'Test::MockModule', 0;
 };
 
 on develop => sub {


### PR DESCRIPTION
Used directly in `t/{eth,rpc}.t`.