### PR TITLE
crypto/send_pong_on_ping_frame

### DIFF
--- a/lib/Net/Async/Blockchain/Client/Websocket.pm
+++ b/lib/Net/Async/Blockchain/Client/Websocket.pm
@@ -115,7 +115,7 @@ sub websocket_client : method {
                 ),
                 on_ping_frame => $self->$curry::weak(
                     sub {
-                        my ($self, undef, $frame) = @_;
+                        my ($self) = @_;
                         $self->websocket_client->send_pong_frame->on_fail(
                             sub {
                                 my $error = shift;


### PR DESCRIPTION
PR changes:
- Keep the WS connection alive by sending a pong frame on the ping frame from the server.